### PR TITLE
Check if hljs has language

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -53,7 +53,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             if (typeof(hljs) === 'undefined') {
                 return htmlize(code);
             }
-            if (lang) {
+            if (lang && hljs.getLanguage(lang)) {
                 return hljs.highlight(code, {language: lang}).value;
             }
             return hljs.highlightAuto(code).value;


### PR DESCRIPTION
For example the Laravel error page has hljs now, which doesn't contain SQL. So that will fail otherwise.