### PR TITLE
Add dev keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "maximebf/debugbar",
     "description": "Debug bar in the browser for php application",
-    "keywords": ["debug", "debugbar"],
+    "keywords": ["debug", "debugbar", "dev"],
     "homepage": "https://github.com/php-debugbar/php-debugbar",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
https://getcomposer.org/doc/04-schema.md#keywords

> Note: Some special keywords trigger composer require without the --dev option to prompt users if they would like to add these packages to require-dev instead of require. These are: dev, testing, static analysis.