### PR TITLE
Fix icon on symfony HtmlDumper

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -113,6 +113,8 @@ div.phpdebugbar-widgets-messages {
   dl.phpdebugbar-widgets-kvlist dd.phpdebugbar-widgets-value pre.sf-dump,
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item pre.sf-dump {
     display: inline-block !important;
+    padding-top: 0px;
+    padding-bottom: 0px;
   }
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector,
   div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label {


### PR DESCRIPTION
**Before**
![image](https://github.com/user-attachments/assets/ca4dfe91-a23a-4299-b571-78e4d1d04920)

**After**
![image](https://github.com/user-attachments/assets/77453189-d391-4e28-abd1-7f76074f7145)

