### PR TITLE
Fix warning on null query parameter

### DIFF
--- a/src/DebugBar/DataCollector/PDO/TracedStatement.php
+++ b/src/DebugBar/DataCollector/PDO/TracedStatement.php
@@ -114,9 +114,12 @@ class TracedStatement
 
         foreach ($this->parameters as $k => $v) {
 
-            $backRefSafeV = strtr($v, $cleanBackRefCharMap);
-
-            $v = "$quoteLeft$backRefSafeV$quoteRight";
+            if (null === $v) {
+                $v = 'NULL';
+            } else {
+                $backRefSafeV = strtr($v, $cleanBackRefCharMap);
+                $v = "$quoteLeft$backRefSafeV$quoteRight";
+            }
 
             if (is_numeric($k)) {
                 $marker = "\?";

--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -53,7 +53,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             if (typeof(hljs) === 'undefined') {
                 return htmlize(code);
             }
-            if (lang) {
+            if (lang && hljs.getLanguage(lang)) {
                 return hljs.highlight(code, {language: lang}).value;
             }
             return hljs.highlightAuto(code).value;


### PR DESCRIPTION
Fix PHP 8 warning in `TracedStatement::getSqlWithParameters()` when null was bound

Since PHP 8.0, [built-in functions like `strtr()` will emit a warning when passing `null` to required string parameters](docs):

```
strtr(): Passing null to parameter #1 ($string) of type string is deprecated
```

This can happen when e.g. binding `PDO::PARAM_NULL` to your query.

[docs]: https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal