### PR TITLE
Allow dataset to defer loading instead of passing all the data

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -84,6 +84,8 @@ class JavascriptRenderer
 
     protected $ajaxHandlerEnableTab = false;
 
+    protected $deferDatasets = false;
+
     protected $openHandlerClass = 'PhpDebugBar.OpenHandler';
 
     protected $openHandlerUrl;
@@ -193,6 +195,9 @@ class JavascriptRenderer
         }
         if (array_key_exists('ajax_handler_enable_tab', $options)) {
             $this->setAjaxHandlerEnableTab($options['ajax_handler_enable_tab']);
+        }
+        if (array_key_exists('defer_datasets', $options)) {
+            $this->setDeferDatasets($options['defer_datasets']);
         }
         if (array_key_exists('open_handler_classname', $options)) {
             $this->setOpenHandlerClass($options['open_handler_classname']);
@@ -639,6 +644,28 @@ class JavascriptRenderer
     public function isAjaxHandlerTabEnabled()
     {
         return $this->ajaxHandlerEnableTab;
+    }
+
+
+    /**
+     * Sets whether datasets are directly loaded or deferred
+     *
+     * @param boolean $enabled
+     */
+    public function setDeferDatasets($defer = true)
+    {
+        $this->deferDatasets = $defer;
+        return $this;
+    }
+
+    /**
+     * Check if the datasets are deffered
+     *
+     * @return boolean
+     */
+    public function areDatasetsDeferred()
+    {
+        return $this->deferDatasets;
     }
 
 
@@ -1110,12 +1137,21 @@ class JavascriptRenderer
 
         if ($renderStackedData && $this->debugBar->hasStackedData()) {
             foreach ($this->debugBar->getStackedData() as $id => $data) {
-                $js .= $this->getAddDatasetCode($id, $data, '(stacked)');
+                if ($this->areDatasetsDeferred()) {
+                    $js .= $this->getLoadDatasetCode($id, '(stacked)');
+                } else {
+                    $js .= $this->getAddDatasetCode($id, $data, '(stacked)');
+
+                }
             }
         }
 
         $suffix = !$initialize ? '(ajax)' : null;
-        $js .= $this->getAddDatasetCode($this->debugBar->getCurrentRequestId(), $this->debugBar->getData(), $suffix);
+        if ($this->areDatasetsDeferred()) {
+            $js .= $this->getLoadDatasetCode($this->debugBar->getCurrentRequestId(), $suffix);
+        } else {
+            $js .= $this->getAddDatasetCode($this->debugBar->getCurrentRequestId(), $this->debugBar->getData(), $suffix);
+        }
 
         $nonce = $this->getNonceAttribute();
 

--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1280,6 +1280,23 @@ class JavascriptRenderer
     }
 
     /**
+     * Returns the js code needed to load a dataset with the OpenHandler
+     *
+     * @param string $requestId
+     * @param mixed $suffix
+     * @return string
+     */
+    protected function getLoadDatasetCode($requestId, $suffix = null)
+    {
+        $js = sprintf("%s.loadDataSet(\"%s\"%s);\n",
+            $this->variableName,
+            $requestId,
+            $suffix ? ", " . json_encode($suffix) : ''
+        );
+        return $js;
+    }
+
+    /**
      * If a nonce it set, create the correct attribute
      * @return string
      */

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1208,9 +1208,11 @@ if (typeof(PhpDebugBar) == 'undefined') {
             }
             var self = this;
             this.openHandler.load(id, function(data) {
-                self.addDataSet(data, id, suffix, show);
-                self.resize();
-                callback && callback(data);
+                if (data) {
+                    self.addDataSet(data, id, suffix, show);
+                    self.resize();
+                    callback && callback(data);
+                }
             });
         },
 

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1153,14 +1153,6 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @return {String} Dataset's id
          */
         addDataSet: function(data, id, suffix, show) {
-            // When data is null, load this async
-            if (id && data === null) {
-                window.setTimeout(() => {
-                    this.loadDataSet(id, suffix, undefined, show);
-                }, 0)
-                return id;
-            }
-
             if (!data || !data.__meta) return;
             if (this.isIframe) {
                 window.top.phpdebugbar.addDataSet(data, id, '(iframe)' + (suffix || ''), show);
@@ -1208,11 +1200,9 @@ if (typeof(PhpDebugBar) == 'undefined') {
             }
             var self = this;
             this.openHandler.load(id, function(data) {
-                if (data) {
-                    self.addDataSet(data, id, suffix, show);
-                    self.resize();
-                    callback && callback(data);
-                }
+                self.addDataSet(data, id, suffix, show);
+                self.resize();
+                callback && callback(data);
             });
         },
 

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -1153,6 +1153,14 @@ if (typeof(PhpDebugBar) == 'undefined') {
          * @return {String} Dataset's id
          */
         addDataSet: function(data, id, suffix, show) {
+            // When data is null, load this async
+            if (id && data === null) {
+                window.setTimeout(() => {
+                    this.loadDataSet(id, suffix, undefined, show);
+                }, 0)
+                return id;
+            }
+
             if (!data || !data.__meta) return;
             if (this.isIframe) {
                 window.top.phpdebugbar.addDataSet(data, id, '(iframe)' + (suffix || ''), show);


### PR DESCRIPTION
Gives the option to defer the loading of the dataset. This gives the change for a request to write more data (eg. terminable middleware) before loading, and make the requests smaller. 

Next step would be to only load or render when the debugbar is open..