### PR TITLE
Map tooltip data

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -837,6 +837,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             $a.append(debugbar.getControl(key[0]).$badge.clone().css('display', 'inline-block').text(d));
                         }
                         $a.appendTo($badges).click(clickHandler);
+                    } else if (key[1] === 'tooltip') {
+                        debugbar.getControl(key[0]).set('tooltip', d);
                     }
                 }
             });


### PR DESCRIPTION
Similar to the badge, add the widget with 
```php

    public function getWidgets()
    {
        return array(
            "time" => array(
                "icon" => "clock-o",
                "tooltip" => "Request Duration",
                "map" => "time.duration_str",
                'link' => 'timeline',
                "default" => "'0ms'"
            ),
            "timeline" => array(
                "icon" => "tasks",
                "widget" => "PhpDebugBar.Widgets.TimelineWidget",
                "map" => "time",
                "default" => "{}"
            ),
            'timeline:tooltip' => array(
                'map' => 'time.tooltip',
                'default' => '{}'
            ),
        );
    }
```
