### PR TITLE
Fix defer data loading

### DIFF
--- a/src/DebugBar/JavascriptRenderer.php
+++ b/src/DebugBar/JavascriptRenderer.php
@@ -1148,6 +1148,7 @@ class JavascriptRenderer
 
         $suffix = !$initialize ? '(ajax)' : null;
         if ($this->areDatasetsDeferred()) {
+            $this->debugBar->getData();
             $js .= $this->getLoadDatasetCode($this->debugBar->getCurrentRequestId(), $suffix);
         } else {
             $js .= $this->getAddDatasetCode($this->debugBar->getCurrentRequestId(), $this->debugBar->getData(), $suffix);


### PR DESCRIPTION
I tried to test this functionality and I always get that the file does not exist, and in the sources the file is saved when doing `getData()`, with this change it works for me, or am I doing something wrong?
https://github.com/php-debugbar/php-debugbar/blob/917a032fbab522e0b82232a12fd1eeb439020919/src/DebugBar/DebugBar.php#L248-L252

Ref #723