### PR TITLE
Avoid LF, \t, multiple spaces on timeline

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -526,7 +526,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             width: width + "%"
                         }));
                         m.append($('<span />').addClass(csscls('label'))
-                            .text(measure.label + ( measure.duration ? " (" + measure.duration_str +(measure.memory ? '/' + measure.memory_str: '') + ")" : "")));
+                            .text(measure.label.replace(/\s+/g, ' ') + ( measure.duration ? " (" + measure.duration_str +(measure.memory ? '/' + measure.memory_str: '') + ")" : "")));
 
                         if (measure.collector) {
                             $('<span />').addClass(csscls('collector')).text(measure.collector).appendTo(m);
@@ -573,7 +573,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                         width = Math.min((aggregate.data.duration * 100 / data.duration).toFixed(2), 100);
 
                         aggregateTable.append('<tr><td class="' + csscls('name') + '">' +
-                            aggregate.data.count + ' x ' + $('<i />').text(aggregate.label).html() + ' (' + width + '%)</td><td class="' + csscls('value') + '">' +
+                            aggregate.data.count + ' x ' + $('<i />').text(aggregate.label.replace(/\s+/g, ' ')).html() + ' (' + width + '%)</td><td class="' + csscls('value') + '">' +
                             '<div class="' + csscls('measure') +'">' +
                                 '<span class="' + csscls('value') + '"></span>' +
                                 '<span class="' + csscls('label') + '">' + formatDuration(aggregate.data.duration) + (aggregate.data.memory ? '/' + formatBytes(aggregate.data.memory) : '') + '</span>' +


### PR DESCRIPTION
This prevents it from becoming illegible in the cases described

Before this change
![image](https://github.com/user-attachments/assets/65f7c816-80b2-42ee-bc46-025d1b88147b)

After this change
![image](https://github.com/user-attachments/assets/883bbed2-ff13-44e8-8923-b7aca4b1ccf5)
