### PR TITLE
Query code after buttons block

### DIFF
--- a/src/DebugBar/Resources/widgets/sqlqueries/widget.js
+++ b/src/DebugBar/Resources/widgets/sqlqueries/widget.js
@@ -74,11 +74,6 @@
             var filters = [], self = this;
 
             this.$list = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, stmt) {
-                if (stmt.type === 'transaction') {
-                    $('<strong />').addClass(csscls('sql')).addClass(csscls('name')).text(stmt.sql).appendTo(li);
-                } else {
-                    $('<code />').addClass(csscls('sql')).html(PhpDebugBar.Widgets.highlight(stmt.sql, 'sql')).appendTo(li);
-                }
                 if (stmt.width_percent) {
                     $('<div />').addClass(csscls('bg-measure')).append(
                         $('<div />').addClass(csscls('value')).css({
@@ -137,6 +132,11 @@
                         }
                     }).addClass(csscls('editor-link')).appendTo(header);
                     header.appendTo(li);
+                }
+                if (stmt.type === 'transaction') {
+                    $('<strong />').addClass(csscls('sql')).addClass(csscls('name')).text(stmt.sql).appendTo(li);
+                } else {
+                    $('<code />').addClass(csscls('sql')).html(PhpDebugBar.Widgets.highlight(stmt.sql, 'sql')).appendTo(li);
                 }
                 if (typeof(stmt.is_success) != 'undefined' && !stmt.is_success) {
                     li.addClass(csscls('error'));


### PR DESCRIPTION
This allows that if the query is too large or the window is too small the buttons stay at the top, currently they go to the bottom making their access more difficult in large queries or with many line breaks

![image](https://github.com/user-attachments/assets/f1bfc357-18a0-44fd-9e6c-75a7885740bb)
