### PR TITLE
Hide cero count tabs

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -284,7 +284,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.bindAttr('data', function(data) {
                 if (this.has('widget')) {
                     this.get('widget').set('data', data);
-                    this.$tab.attr('data-empty', $.isEmptyObject(data));
+                    this.$tab.attr('data-empty', $.isEmptyObject(data) || data.count === 0);
                 }
             })
         }


### PR DESCRIPTION
Some collectors handle `count` key, 
and if it is zero it should be hidden, or not?

https://github.com/php-debugbar/php-debugbar/blob/3f589bbbaed53039d9699702c2908148647c27a1/src/DebugBar/DataCollector/MessagesCollector.php#L213
https://github.com/php-debugbar/php-debugbar/blob/3f589bbbaed53039d9699702c2908148647c27a1/src/DebugBar/DataCollector/ObjectCountCollector.php#L71
https://github.com/php-debugbar/php-debugbar/blob/3f589bbbaed53039d9699702c2908148647c27a1/src/DebugBar/Bridge/Symfony/SymfonyMailCollector.php#L76
https://github.com/php-debugbar/php-debugbar/blob/3f589bbbaed53039d9699702c2908148647c27a1/src/DebugBar/Bridge/SwiftMailer/SwiftMailCollector.php#L56
https://github.com/php-debugbar/php-debugbar/blob/3f589bbbaed53039d9699702c2908148647c27a1/src/DebugBar/Bridge/MonologCollector.php#L86