### PR TITLE
build: replace maximebf/debugbar in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "psr/log": "^1|^2|^3",
         "symfony/var-dumper": "^4|^5|^6|^7"
     },
+    "replace": {
+        "maximebf/debugbar": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",
         "twig/twig": "^1.38|^2.7|^3.0",


### PR DESCRIPTION
I'm using a plugin for the debugbar that still requires `maximebf/debugbar`, so now I have two versions installed with the same classes. By using the replace, we can make sure only the new package name is installed.