### PR TITLE
fixing typo in documentation about Renderable interface

### DIFF
--- a/docs/data_collectors.md
+++ b/docs/data_collectors.md
@@ -46,7 +46,7 @@ same time the `DebugBar::collect()` method is called.
 
 This however won't show anything in the debug bar as no information are provided
 on how to display these data. You could do that manually as you'll see in later chapter
-or implement the `DebugBar\DataSource\Renderable` interface.
+or implement the `DebugBar\DataCollector\Renderable` interface.
 
 To implement it, you must define a `getWidgets()` function which returns an array
 of key/value pairs where key are control names and values control options as defined


### PR DESCRIPTION
Seems that the class suggested for `Renderable` interface is wrong in descriptive text, but right in sample code.