### PR TITLE
OPT-IN Start collecting warnings, notices and deprecations on ExceptionsCollector

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -10,7 +10,7 @@
 
 namespace DebugBar\DataCollector;
 
-use Exception;
+use Throwable;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
@@ -24,10 +24,10 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Adds an exception to be profiled in the debug bar
      *
-     * @param Exception $e
+     * @param \Exception $e
      * @deprecated in favor on addThrowable
      */
-    public function addException(Exception $e)
+    public function addException(\Exception $e)
     {
         $this->addThrowable($e);
     }
@@ -35,7 +35,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Adds a Throwable to be profiled in the debug bar
      *
-     * @param \Throwable $e
+     * @param Throwable $e
      */
     public function addThrowable($e)
     {
@@ -135,11 +135,11 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns exception data as an array
      *
-     * @param Exception $e
+     * @param \Exception $e
      * @return array
      * @deprecated in favor on formatThrowableData
      */
-    public function formatExceptionData(Exception $e)
+    public function formatExceptionData(\Exception $e)
     {
         return $this->formatThrowableData($e);
     }
@@ -178,7 +178,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns Throwable data as an string
      *
-     * @param \Throwable $e
+     * @param Throwable $e
      * @return string
      */
     public function formatTraceAsString($e)
@@ -200,7 +200,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     /**
      * Returns Throwable data as an array
      *
-     * @param \Throwable|array $e
+     * @param Throwable|array $e
      * @return array
      */
     public function formatThrowableData($e)

--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -54,6 +54,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
     {
         $this->chainExceptions = $chainExceptions;
     }
+
     /**
      * Start collecting warnings, notices and deprecations
      *


### PR DESCRIPTION
It would be great to be able to collect the other types of errors that don't stop the script from running.

**Example:**
```php
$cadena = "";
$cadena--;
```
![image](https://github.com/user-attachments/assets/d3b515b9-4ab2-45a0-a0dc-c8ae0bbfbb81)
