### PR TITLE
ExceptionsCollector easy to extend

### DIFF
--- a/src/DebugBar/DataCollector/ExceptionsCollector.php
+++ b/src/DebugBar/DataCollector/ExceptionsCollector.php
@@ -18,8 +18,24 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
  */
 class ExceptionsCollector extends DataCollector implements Renderable
 {
+    /** @var string */
+    private $name;
+    /** @var string */
+    private $icon;
+    /** @var array */
     protected $exceptions = array();
+    /** @var bool */
     protected $chainExceptions = false;
+
+    /**
+     * @param string $name
+     * @param string $icon
+     */
+    public function __construct($name = 'exceptions', $icon = 'bug')
+    {
+        $this->name = $name;
+        $this->icon = $icon;
+    }
 
     /**
      * Adds an exception to be profiled in the debug bar
@@ -178,7 +194,7 @@ class ExceptionsCollector extends DataCollector implements Renderable
      */
     public function getName()
     {
-        return 'exceptions';
+        return $this->name;
     }
 
     /**
@@ -186,15 +202,17 @@ class ExceptionsCollector extends DataCollector implements Renderable
      */
     public function getWidgets()
     {
+        $name = $this->getName();
+
         return array(
-            'exceptions' => array(
-                'icon' => 'bug',
+            "$name" => array(
+                'icon' => $this->icon,
                 'widget' => 'PhpDebugBar.Widgets.ExceptionsWidget',
-                'map' => 'exceptions.exceptions',
+                'map' => "$name.exceptions",
                 'default' => '[]'
             ),
-            'exceptions:badge' => array(
-                'map' => 'exceptions.count',
+            "$name:badge" => array(
+                'map' => "$name.count",
                 'default' => 'null'
             )
         );


### PR DESCRIPTION
In case #748 doesn't get merged, i could extend the class with that code and just return
```php
public function collect() {
    return array(
        'count' => count($this->exceptions),
        'exceptions' => $this->exceptions
    );
}
```
Also for anyone who wants to extend the same class, just with another name