### PR TITLE
Compact symfony var dumper, and better text

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -635,6 +635,8 @@ if (typeof(PhpDebugBar) == 'undefined') {
                 }
                 if (e.stack_trace_html) {
                     var $trace = $('<span />').addClass(csscls('filename')).html(e.stack_trace_html);
+                    $trace.find('samp[data-depth="1"]').removeClass('sf-dump-expanded').addClass('sf-dump-compact').parent()
+                        .find('>.sf-dump-note').html((_, t) => t.replace(/^array:/, '<span class="sf-dump-key">Stack Trace:</span> ') + ' files');
                     $trace.appendTo(li);
                 } else if (e.stack_trace) {
                     e.stack_trace.split("\n").forEach(function (trace) {


### PR DESCRIPTION
It's easier to read when there is more than one exception. Most of the time it is not necessary to see all the traces

Before 
![image](https://github.com/user-attachments/assets/18c93db4-c825-4f51-9fd4-ebce847f690c)

After
![image](https://github.com/user-attachments/assets/5a3b52a4-4080-43d6-9112-2a12d8b42bfe)

