### PR TITLE
Reset debugbar DOM position

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -5,6 +5,10 @@
   }
 }
 
+div.phpdebugbar, div.phpdebugbar *, div.phpdebugbar :after, div.phpdebugbar :before {
+  position: static;
+}
+
 div.phpdebugbar,
 div.phpdebugbar-openhandler {
   --debugbar-background: #fff;


### PR DESCRIPTION
Some CSS components can globally change the position
I try to reset to maintain consistency across different apps