### PR TITLE
Fix debugbar z-index

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -79,7 +79,7 @@ div.phpdebugbar {
   border-top: 0;
   font-family: var(--debugbar-font-sans);
   background: var(--debugbar-background);
-  z-index: 10000;
+  z-index: 10000000000;
   font-size: 14px;
   color: var(--debugbar-text);
   text-align: left;


### PR DESCRIPTION
[php-debugbar](https://github.com/php-debugbar/php-debugbar) is hidden under other components,
so I add 1 to the z-index and it works

> z-index: 9999999999;

**Source:** [filp/whoops/src/Whoops/Resources/css/whoops.base.css#L17C14-L17C24](https://github.com/filp/whoops/blob/075bc0c26631110584175de6523ab3f1652eb28e/src/Whoops/Resources/css/whoops.base.css#L17C14-L17C24)