### PR TITLE
Blacklist keys on Request for hide sensitive data

### DIFF
--- a/src/DebugBar/DataCollector/RequestDataCollector.php
+++ b/src/DebugBar/DataCollector/RequestDataCollector.php
@@ -16,25 +16,88 @@ namespace DebugBar\DataCollector;
 class RequestDataCollector extends DataCollector implements Renderable, AssetProvider
 {
     /**
+     * @var array[]
+     */
+    private $blacklist = [
+        '_GET' => [],
+        '_POST' => [],
+        '_COOKIE' => [],
+        '_SESSION' => [],
+    ];
+
+    /**
      * @return array
      */
     public function collect()
     {
-        $vars = array('_GET', '_POST', '_SESSION', '_COOKIE');
+        $vars = array_keys($this->blacklist);
         $data = array();
 
         foreach ($vars as $var) {
-            if (isset($GLOBALS[$var])) {
-                $key = "$" . $var;
-                if ($this->isHtmlVarDumperUsed()) {
-                    $data[$key] = $this->getVarDumper()->renderVar($GLOBALS[$var]);
-                } else {
-                    $data[$key] = $this->getDataFormatter()->formatVar($GLOBALS[$var]);
-                }
+            if (! isset($GLOBALS[$var])) {
+                continue;
+            }
+
+            $key = "$" . $var;
+            $value = $this->masked($GLOBALS[$var], $var);
+
+            if ($this->isHtmlVarDumperUsed()) {
+                $data[$key] = $this->getVarDumper()->renderVar($value);
+            } else {
+                $data[$key] = $this->getDataFormatter()->formatVar($value);
             }
         }
 
         return $data;
+    }
+
+    /**
+     * Hide a sensitive value within one of the superglobal arrays.
+     *
+     * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
+     * @param string|array $key       The key within the superglobal
+     * @return void
+     */
+    public function hideSuperglobalKeys($superGlobalName, $keys)
+    {
+        if (!is_array($keys)) {
+            $keys = [$keys];
+        }
+
+        if (!isset($this->blacklist[$superGlobalName])) {
+            $this->blacklist[$superGlobalName] = [];
+        }
+
+        foreach ($keys as $key) {
+            $this->blacklist[$superGlobalName][] = $key;
+        }
+    }
+
+    /**
+     * Checks all values within the given superGlobal array.
+     *
+     * Blacklisted values will be replaced by a equal length string containing
+     * only '*' characters for string values.
+     * Non-string values will be replaced with a fixed asterisk count.
+     *
+     * @param array|\ArrayAccess  $superGlobal     One of the superglobal arrays
+     * @param string $superGlobalName The name of the superglobal array, e.g. '_GET'
+     *
+     * @return array $values without sensitive data
+     */
+    private function masked($superGlobal, $superGlobalName)
+    {
+        $blacklisted = $this->blacklist[$superGlobalName];
+
+        $values = $superGlobal;
+
+        foreach ($blacklisted as $key) {
+            if (isset($superGlobal[$key])) {
+                $values[$key] = str_repeat('*', is_string($superGlobal[$key]) ? strlen($superGlobal[$key]) : 3);
+            }
+        }
+
+        return $values;
     }
 
     /**


### PR DESCRIPTION
Code usage:
```php
$debugbar['request']->hideSuperglobalKeys('_COOKIE', ['PHPSESSID', 'MY_COOKIE']);
```

Same as Whoops

[Whoops/Handler/PrettyPageHandler.php#L807-L833](https://github.com/filp/whoops/blob/075bc0c26631110584175de6523ab3f1652eb28e/src/Whoops/Handler/PrettyPageHandler.php#L807-L833)
[Whoops/Handler/PrettyPageHandler.php#L86-L94](https://github.com/filp/whoops/blob/075bc0c26631110584175de6523ab3f1652eb28e/src/Whoops/Handler/PrettyPageHandler.php#L86-L94)