### PR TITLE
Name of the parameter easier to read in the timeline

### DIFF
--- a/src/DebugBar/Resources/widgets.css
+++ b/src/DebugBar/Resources/widgets.css
@@ -276,6 +276,7 @@ ul.phpdebugbar-widgets-timeline {
       ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params .phpdebugbar-widgets-name {
         width: 20%;
         font-weight: bold;
+        vertical-align: top;
       }
 
 /* -------------------------------------- */


### PR DESCRIPTION
If the value is a large array, the name makes `vertical-align: middle;`, its usefulness is lost
![image](https://github.com/user-attachments/assets/e306af7a-8311-4a6e-9bd7-16817b5d1947)
