### PR TITLE
Fix filename position on message collector

### DIFF
--- a/src/DebugBar/Resources/widgets.js
+++ b/src/DebugBar/Resources/widgets.js
@@ -366,7 +366,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                             $('<a href="' + value.xdebug_link.url + '"></a>').addClass(csscls('editor-link')).appendTo(header);
                         }
                     }
-                    header.appendTo(li);
+                    header.prependTo(li);
                 }
                 if (value.collector) {
                     $('<span />').addClass(csscls('collector')).text(value.collector).prependTo(li);


### PR DESCRIPTION
The file name must be prepended, on small windows or wide array messages, the filename is pushed down