### PR TITLE
fix symfony var-dumper css on dark theme

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -194,6 +194,10 @@ div.phpdebugbar pre.sf-dump {
   outline: 0;
 }
 
+div.phpdebugbar pre.sf-dump .sf-dump-private {
+  color: grey;
+}
+
 div.phpdebugbar[data-theme='dark'] pre.sf-dump .sf-dump-public {
   color: #ffcc00;
 }

--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -194,6 +194,18 @@ div.phpdebugbar pre.sf-dump {
   outline: 0;
 }
 
+div.phpdebugbar[data-theme='dark'] pre.sf-dump .sf-dump-public {
+  color: #ffcc00;
+}
+
+div.phpdebugbar[data-theme='dark'] pre.sf-dump .sf-dump-protected {
+  color: #a0a000;
+}
+
+div.phpdebugbar[data-theme='dark'] pre.sf-dump .sf-dump-private {
+  color: #9d9266;
+}
+
 a.phpdebugbar-restore-btn {
   float: left;
   padding: 5px 8px;


### PR DESCRIPTION
From 
![image](https://github.com/user-attachments/assets/46e915ba-89a1-485f-941c-b9752f946f4c)

To
![image](https://github.com/user-attachments/assets/0c963fc8-dfff-4918-b245-5e7e72931630)

Closes https://github.com/barryvdh/laravel-debugbar/issues/1771