### PR TITLE
fix for PhpRedis >= 6.1.0 in RedisStorage

### DIFF
--- a/src/DebugBar/Storage/RedisStorage.php
+++ b/src/DebugBar/Storage/RedisStorage.php
@@ -56,8 +56,11 @@ class RedisStorage implements StorageInterface
     public function find(array $filters = [], $max = 20, $offset = 0)
     {
         $results = [];
-        $cursor = "0";
         $isPhpRedis = get_class($this->redis) === 'Redis' || get_class($this->redis) === 'RedisCluster';
+        $cursor = match (true) {
+            $isPhpRedis && version_compare(phpversion('redis'), '6.1.0', '>=') => null,
+            default => '0',
+        };
 
         do {
             if ($isPhpRedis) {


### PR DESCRIPTION
For PhpRedis >= 6.1.0 cursor MUST be null for the first run of the `[hsz]scan`

Solution inspired by the one in the Laravel Framework

```php
        $defaultCursorValue = match (true) {
            $connection instanceof PhpRedisConnection && version_compare(phpversion('redis'), '6.1.0', '>=') => null,
            default => '0',
        };
```

https://github.com/laravel/framework/blob/f18288f30c3c0007df6d20474c72ea2bed1af4d8/src/Illuminate/Cache/RedisStore.php#L316-L319
