### PR TITLE
bugfix(redis-storage): Unserialise is sometimes false

### DIFF
--- a/src/DebugBar/Storage/RedisStorage.php
+++ b/src/DebugBar/Storage/RedisStorage.php
@@ -46,7 +46,7 @@ class RedisStorage implements StorageInterface
      */
     public function get($id)
     {
-        return array_merge(unserialize($this->redis->hGet("$this->hash:data", $id)),
+        return array_merge(unserialize($this->redis->hGet("$this->hash:data", $id)) ?: [],
             array('__meta' => unserialize($this->redis->hGet("$this->hash:meta", $id))));
     }
 


### PR DESCRIPTION
This is likely indicative of a deeper issue with the data being fetched but when there is a problem with unserialize, we should fallback to an empty array when the unserialize function returns false.