### PR TITLE
Fix version replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/var-dumper": "^4|^5|^6|^7"
     },
     "replace": {
-        "maximebf/debugbar": "*"
+        "maximebf/debugbar": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",


### PR DESCRIPTION
If I understood correctly `self.version` would also be useful for this case

https://getcomposer.org/doc/04-schema.md#replace
>You should then typically only replace using `self.version` as a version constraint, to make sure the main package only replaces the sub-packages of that exact version, and not any other version, which would be incorrect.

Maybe closes #779