### PR TITLE
Support html on templates widgets name parameter

### DIFF
--- a/src/DebugBar/Resources/widgets/templates/widget.js
+++ b/src/DebugBar/Resources/widgets/templates/widget.js
@@ -16,7 +16,12 @@
             this.$status = $('<div />').addClass(csscls('status')).appendTo(this.$el);
 
             this.$list = new  PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, tpl) {
-                $('<span />').addClass(csscls('name')).text(tpl.name).appendTo(li);
+                var name = $('<span />').addClass(csscls('name')).appendTo(li);
+                if (tpl.html) {
+                    name.html(tpl.html);
+                } else {
+                    name.text(tpl.name);
+                }
 
                 if (typeof tpl.xdebug_link !== 'undefined' && tpl.xdebug_link !== null) {
                     var header = $('<span />').addClass(csscls('filename')).text(tpl.xdebug_link.filename + ( tpl.xdebug_link.line ? "#" + tpl.xdebug_link.line : ''));


### PR DESCRIPTION
Only when `tpl.html` exists, it adds html to list names
It shouldn't affect backwards, because only `name` has existed, never `html`

Why?
I'm trying to add the latest Git modification data to my collector, but when I send HTML, it interprets it as text.

<img width="1135" height="113" alt="image" src="https://github.com/user-attachments/assets/b635a9ef-5f7a-41a5-bac9-63f706ad153b" />


