### PR TITLE
Fix #790 - Slow threshold highlight on queries

### DIFF
--- a/src/DebugBar/DataCollector/PDO/PDOCollector.php
+++ b/src/DebugBar/DataCollector/PDO/PDOCollector.php
@@ -64,7 +64,7 @@ class PDOCollector extends DataCollector implements Renderable, AssetProvider
      */
     public function setSlowThreshold($threshold)
     {
-        $this->slowThreshold = $threshold;
+        $this->slowThreshold = $threshold / 1000;
     }
 
     /**


### PR DESCRIPTION
>- #790
>
> ```php
> $debugbar['pdo']->setSlowThreshold(100); // time on ms
> ```

To make it work with milliseconds you have to divide by 1000