### PR TITLE
Add support for VSCode WSL Xdebug links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+# VSCode WSL Remote Xdebug Link Support
+
+This package now supports generating Xdebug file links for VS Code running in WSL (Windows Subsystem for Linux) via the `vscode-wsl` editor type.
+
+## Usage
+
+Set the editor link template to `vscode-wsl`:
+
+```php
+$debugbar->setEditorLinkTemplate('vscode-wsl');
+```
+
+You can configure the WSL distribution name (e.g., `Ubuntu`) using:
+
+- The `DEBUGBAR_WSL_NAME` environment variable
+- The `setWslName()` method
+
+If not set, it defaults to `Ubuntu`.
+
+## Example Link
+
+The generated link will look like:
+
+```
+vscode://vscode-remote/wsl+Ubuntu/path/to/file.php:1
+```
+
+Clicking this link in your browser on Windows will open the file in VS Code inside your WSL environment.
 # PHP Debug Bar
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/php-debugbar/php-debugbar?label=Stable)](https://packagist.org/packages/php-debugbar/php-debugbar) [![Total Downloads](https://img.shields.io/packagist/dt/maximebf/debugbar?label=Downloads)](https://packagist.org/packages/php-debugbar/php-debugbar) [![License](https://img.shields.io/badge/Licence-MIT-4d9283)](https://packagist.org/packages/php-debugbar/php-debugbar) [![Tests](https://github.com/maximebf/php-debugbar/actions/workflows/run-tests.yml/badge.svg)](https://github.com/php-debugbar/php-debugbar/actions/workflows/run-tests.yml)

--- a/tests/DebugBar/Tests/HasXdebugLinksTest.php
+++ b/tests/DebugBar/Tests/HasXdebugLinksTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use DebugBar\DataFormatter\HasXdebugLinks;
+
+class HasXdebugLinksTest extends TestCase
+{
+    use HasXdebugLinks;
+
+    public function testVscodeWslLinkGeneration()
+    {
+        $this->setEditorLinkTemplate('vscode-wsl');
+        $this->setWslName('CustomWSL');
+        $file = '/var/www/html/index.php';
+        $line = 42;
+        $link = $this->getXdebugLink($file, $line);
+        $this->assertStringContainsString('vscode://vscode-remote/wsl+CustomWSL', $link['url']);
+        $this->assertStringContainsString('index.php:42', urldecode($link['url']));
+    }
+}

--- a/tests/DebugBar/Tests/HasXdebugLinksTest.php
+++ b/tests/DebugBar/Tests/HasXdebugLinksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DebugBar\Tests;
+
 use PHPUnit\Framework\TestCase;
 use DebugBar\DataFormatter\HasXdebugLinks;
 
@@ -16,5 +18,29 @@ class HasXdebugLinksTest extends TestCase
         $link = $this->getXdebugLink($file, $line);
         $this->assertStringContainsString('vscode://vscode-remote/wsl+CustomWSL', $link['url']);
         $this->assertStringContainsString('index.php:42', urldecode($link['url']));
+    }
+
+    public function testVscodeWslLinkGenerationWithDefaultWslName()
+    {
+        $this->setEditorLinkTemplate('vscode-wsl');
+        // Do not set WSL name, should default to 'Ubuntu'
+        $file = '/var/www/html/test.php';
+        $line = 5;
+        $link = $this->getXdebugLink($file, $line);
+        $this->assertStringContainsString('vscode://vscode-remote/wsl+Ubuntu', $link['url']);
+        $this->assertStringContainsString('test.php:5', urldecode($link['url']));
+    }
+
+    public function testVscodeWslLinkGenerationWithEnvVar()
+    {
+        $this->setEditorLinkTemplate('vscode-wsl');
+        putenv('DEBUGBAR_WSL_NAME=EnvWSL');
+        // Do not set WSL name via setter, should use env var
+        $file = '/var/www/html/env.php';
+        $line = 7;
+        $link = $this->getXdebugLink($file, $line);
+        $this->assertStringContainsString('vscode://vscode-remote/wsl+EnvWSL', $link['url']);
+        $this->assertStringContainsString('env.php:7', urldecode($link['url']));
+        putenv('DEBUGBAR_WSL_NAME'); // Clean up
     }
 }


### PR DESCRIPTION
This PR adds support for generating Xdebug file links for VSCode WSL (`vscode-wsl`).

- Supports custom WSL distro via setter, env var, or default (Ubuntu).
- Includes PHPUnit tests for all cases.

Example link:
[vscode://vscode-remote/wsl+Ubuntu/path/to/file.php:1](url)