### PR TITLE
Handle mail body fallback to HTML content on Mail Text Version(mail widget)

### DIFF
--- a/resources/widgets/mails/widget.js
+++ b/resources/widgets/mails/widget.js
@@ -59,7 +59,7 @@
                         bodyPre.style.border = '1px solid #ddd';
                         bodyPre.style.padding = '5px';
                         bodyPre.style.overflowX = 'scroll';
-                        bodyPre.textContent = mail.body;
+                        bodyPre.textContent = mail.body || mail.html;
 
                         let bodyHTML = bodyPre.outerHTML;
                         let htmlIframeHTML = '';


### PR DESCRIPTION
When the email is in HTML format, the text version is always empty.
Is it possible to show the raw HTML as the text plain version?

<img width="479" height="213" alt="image" src="https://github.com/user-attachments/assets/4b57422f-0cd2-45ee-a77c-e8b90f45a88f" />
