### PR TITLE
fix(query-formatter): handle boolean SQL bindings

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -97,6 +97,8 @@ class QueryFormatter extends DataFormatter
 
             if ($binding === null) {
                 $binding = 'NULL';
+            } elseif (is_bool($binding)) {
+                $binding = $binding ? 'TRUE' : 'FALSE';
             } elseif (! is_int($binding) && ! is_float($binding)) {
                 $binding = $this->quoteBinding($binding, $pdo);
             }


### PR DESCRIPTION
Handle boolean values separately when formatting SQL queries with bindings.

Previously, boolean bindings were passed directly to quoteBinding(), which accepts only string values. With strict types enabled, this caused the following TypeError:

QueryFormatter::quoteBinding(): Argument #1 ($binding) must be of type string, bool given

Convert boolean values to SQL literals:

true → TRUE
false → FALSE

This prevents formatter errors and produces a valid, readable SQL representation for boolean bindings.